### PR TITLE
Adding class patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Refer to [https://tools.suckless.org/tabbed/](https://tools.suckless.org/tabbed/
 
 ### Changelog:
 
+2025-01-19 - Added the class patch.
+
 2023-10-26 - Added the separator, drag, basenames, move-clamped and xresources reload patches
 
 2022-03-14 - Added the awesomebar patch
@@ -49,6 +51,9 @@ Refer to [https://tools.suckless.org/tabbed/](https://tools.suckless.org/tabbed/
 
    - [center](https://github.com/bakkeby/patches/blob/master/tabbed/tabbed-center-0.6-20200512-dabf6a2.diff)
       - centers window titles in tabs
+
+   - class
+      -  Ensures that the `WM_CLASS` X11 property is set with the `-n` flag.
 
    - [clientnumber](https://tools.suckless.org/tabbed/patches/clientnumber/)
       - prints the position number of the client before the window title

--- a/patches.def.h
+++ b/patches.def.h
@@ -106,3 +106,12 @@
  * https://tools.suckless.org/tabbed/patches/xresources-with-reload-signal/
  */
 #define XRESOURCES_RELOAD_PATCH 0
+
+/*
+ * Alongside the WM_NAME property, this patch ensures that the WM_CLASS
+ * X11 property is set based on the name provided via the -n flag.
+ *
+ * Without this patch, window rules for tabbed windows may behave
+ * unexpectedly in certain window managers, including DWM.
+ */
+#define CLASS_PATCH 0

--- a/tabbed.c
+++ b/tabbed.c
@@ -61,6 +61,9 @@ enum {
 	#if ICON_PATCH
 	WMIcon,
 	#endif // ICON_PATCH
+	#if CLASS_PATCH
+	WMClass,
+	#endif // CLASS_PATCH
 	WMLast
 }; /* default atoms */
 
@@ -198,6 +201,9 @@ static int cmd_append_pos;
 static char winid[64];
 static char **cmd;
 static char *wmname = "tabbed";
+#if CLASS_PATCH
+static char *wmclass= "tabbed";
+#endif // CLASS_PATCH
 static const char *geometry;
 #if HIDETABS_PATCH
 static Bool barvisibility = False;
@@ -1190,6 +1196,9 @@ setup(void)
 	wmatom[WMFullscreen] = XInternAtom(dpy, "_NET_WM_STATE_FULLSCREEN",
 	                                   False);
 	wmatom[WMName] = XInternAtom(dpy, "_NET_WM_NAME", False);
+	#if CLASS_PATCH
+	wmatom[WMName] = XInternAtom(dpy, "_NET_WM_NAME", False);
+	#endif // CLASS_PATCH
 	wmatom[WMProtocols] = XInternAtom(dpy, "WM_PROTOCOLS", False);
 	wmatom[WMSelectTab] = XInternAtom(dpy, "_TABBED_SELECT_TAB", False);
 	wmatom[WMState] = XInternAtom(dpy, "_NET_WM_STATE", False);
@@ -1308,7 +1317,11 @@ setup(void)
 	xerrorxlib = XSetErrorHandler(xerror);
 
 	class_hint.res_name = wmname;
+	#if CLASS_PATCH
+	class_hint.res_class = wmclass;
+	#else
 	class_hint.res_class = "tabbed";
+	#endif // CLASS_PATCH
 	XSetClassHint(dpy, win, &class_hint);
 
 	size_hint = XAllocSizeHints();
@@ -1577,6 +1590,9 @@ main(int argc, char *argv[])
 		break;
 	case 'n':
 		wmname = EARGF(usage());
+		#if CLASS_PATCH
+		wmclass = wmname;
+		#endif // CLASS_PATCH
 		break;
 	case 'O':
 		normfgcolor = EARGF(usage());


### PR DESCRIPTION
Alongside the WM_NAME property, this patch ensures that the WM_CLASS X11 property is set based on the name provided via the `-n` flag.

Without this patch, window rules for tabbed windows may behave unexpectedly in certain window managers, including DWM as they tend use WM_CLASS often for identifying windows.

**Example:**

`CLASS_PATCH` enabled:
```
./tabbed -c -n "flexipatch" -r 2 st -w ''
```

X11 Properties of the window:
```
WM_STATE(WM_STATE):
                window state: Normal
                icon window: 0x0
_NET_WM_ICON(CARDINAL) =
WM_NAME(COMPOUND_TEXT) = "st"
_NET_WM_NAME(COMPOUND_TEXT) = 0x73, 0x74
WM_PROTOCOLS(ATOM): protocols  WM_DELETE_WINDOW
WM_LOCALE_NAME(STRING) = "en_US.UTF-8"
WM_HINTS(WM_HINTS):
WM_NORMAL_HINTS(WM_SIZE_HINTS):
                program specified size: 800 by 600
                program specified minimum size: 0 by 1
WM_CLIENT_MACHINE(STRING) = "<redacted>"
WM_CLASS(STRING) = "flexipatch", "flexipatch"
```